### PR TITLE
Tweak GitHub Actions.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+  workflow_run:
+    workflows: [ "Tests" ]
+    types:
+      - completed
 
 permissions:
   contents: read
@@ -11,6 +15,8 @@ permissions:
 jobs:
   release-build:
     runs-on: ubuntu-latest
+
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -58,7 +64,7 @@ jobs:
       Sign the Python distribution with Sigstore
       and upload them to GitHub Release
     needs:
-    - pypi-publish
+      - pypi-publish
     runs-on: ubuntu-latest
 
     permissions:
@@ -66,29 +72,23 @@ jobs:
       id-token: write
 
     steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        name: release-dists
-        path: dist/
-    - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v3.0.0
-      with:
-        inputs: >-
-          ./dist/*.tar.gz
-          ./dist/*.whl
-    - name: Create GitHub Release
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      run: >-
-        gh release create
-        "$GITHUB_REF_NAME"
-        --repo "$GITHUB_REPOSITORY"
-        --notes ""
-    - name: Upload artifact signatures to GitHub Release
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      run: >-
-        gh release upload
-        "$GITHUB_REF_NAME" dist/**
-        --repo "$GITHUB_REPOSITORY"
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create
+          "$GITHUB_REF_NAME"
+          --repo "$GITHUB_REPOSITORY"
+          --notes ""
+      - name: Upload artifact signatures to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release upload
+          "$GITHUB_REF_NAME" dist/**
+          --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -36,6 +36,11 @@ jobs:
           name: release-dists
           path: dist/
 
+      - name: Get package version
+        id: get_version
+        run: |
+          echo "VERSION=$(python -c 'from angets import __version__; print(__version__)')" >> $GITHUB_ENV
+
   pypi-publish:
     runs-on: ubuntu-latest
     needs:
@@ -77,18 +82,29 @@ jobs:
         with:
           name: release-dists
           path: dist/
+      - name: Sign the dists with Sigstore
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        with:
+          inputs: >-
+            ./dist/*.tar.gz
+            ./dist/*.whl
+      - name: Create Git tag
+        run: |
+          git tag -a "$VERSION" -m "Release v$VERSION"
+          git push origin "$VERSION"
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: >-
           gh release create
-          "$GITHUB_REF_NAME"
+          "$VERSION"
+          --title "Release v$VERSION"
           --repo "$GITHUB_REPOSITORY"
-          --notes ""
+          --generate-notes
       - name: Upload artifact signatures to GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: >-
           gh release upload
-          "$GITHUB_REF_NAME" dist/**
+          "$VERSION" dist/**
           --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,14 +1,18 @@
 name: Tests
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore: [ "*.md" ]
+  pull_request:
+    paths-ignore: [ "*.md" ]
 
 jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.11", "3.12", "3.13"]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        python-version: [ "3.11", "3.12", "3.13" ]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -55,15 +55,3 @@ It should be a useful utility tool to mitigate against invalid user inputs.
 Actually, I don't expect anyone else other than me to use this package.
 \
 But if you find it useful enough to want to contribute, be my guest!
-
-## Changes
-
-Created:
-
-- 19 February 2025.
-
-Revised:
-
-- 21 February 2025.
-  1. Fixed the installation command.
-  2. Added a new image.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ check_untyped_defs = true
 
 [project]
 name = "angets"
-version = "0.1.2"
+version = "0.1.3"
 authors = [
     { name = "Ankhbold Batbaatar", email = "ankhasgreens@gmail.com" },
 ]

--- a/src/angets/__init__.py
+++ b/src/angets/__init__.py
@@ -1,6 +1,7 @@
 """Angets (Ankha's Gets): Functions for user input."""
+import importlib.metadata
 
-__version__ = '0.1.2'
+__version__: str = importlib.metadata.version('angets')
 
 from angets._core import (
     get_non_empty_str, get_constrained_number, get_float, get_constrained_float, get_positive_float,


### PR DESCRIPTION
# Changelog

- publish.yaml now requires that all tests pass before releasing the package
- Indentation fixes for publish.yaml and tests.yaml
- tests.yaml will not run if only .md files are updated
- README.md does not contain changelogs for itself anymore
- Package `__version__` will now reference the version found in project.toml file